### PR TITLE
Create docker-compose-mount-nfs

### DIFF
--- a/docker-compose-mount-nfs
+++ b/docker-compose-mount-nfs
@@ -1,0 +1,36 @@
+version: '3.5'
+services:
+  plex:
+    container_name: plex
+    image: plexinc/pms-docker:beta
+    restart: unless-stopped
+    ports:
+      - 32400:32400/tcp
+      - 8324:8324/tcp
+      - 32469:32469/tcp
+      - 1900:1900/udp
+      - 32410:32410/udp
+      - 32412:32412/udp
+      - 32413:32413/udp
+      - 32414:32414/udp
+    environment:
+      - TZ=<timezone>
+      - PLEX_CLAIM=<claimToken>
+      - ADVERTISE_IP=http://<hostIPAddress>:32400/
+    hostname: <hostname>
+    volumes:
+      - <path/to/plex/database>:/config
+      - <path/to/transcode/temp>:/transcode
+      - type: volume
+        source: nfs-storage
+        target: /data
+        volume:
+          nocopy: true
+
+volumes:
+  nfs-storage:
+    driver_opts:
+      type: "nfs"
+      o: "addr=<nfs server>,nolock,soft,rw"
+      device: ":/<nfs share to mount>"
+


### PR DESCRIPTION
Created a docker-compose example to show how to mount an NFS export directly in the container.  This is useful to access media stored on an NFS server without having to prep the docker host (mount the nfs export on the host).